### PR TITLE
Add .isort.cfg with a known_third_party line when the line doesn't exist

### DIFF
--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -13,7 +13,13 @@ from aspy.refactor_imports.classify import classify_import
 from aspy.refactor_imports.classify import ImportType
 
 
-SUPPORTED_CONF_FILES = ('.editorconfig', '.isort.cfg', 'setup.cfg', 'tox.ini')
+DEFAULT_CONF_FILE = '.isort.cfg'
+SUPPORTED_CONF_FILES = (
+    DEFAULT_CONF_FILE,
+    '.editorconfig',
+    'setup.cfg',
+    'tox.ini',
+)
 THIRD_PARTY_RE = re.compile(r'^known_third_party(\s*)=(\s*?)[^\s]*$', re.M)
 
 
@@ -68,7 +74,7 @@ def main(argv=None):
                 f.write(contents)
             break
     else:
-        if os.path.exists('.isort.cfg'):
+        if os.path.exists(DEFAULT_CONF_FILE):
             prefix = 'Updating'
             mode = 'a'
             contents = 'known_third_party = {}\n'.format(third_party)
@@ -81,11 +87,13 @@ def main(argv=None):
 
         print(
             '{} an .isort.cfg with a known_third_party setting. '
-            'Feel free to move the setting to a different config file in '
-            'one of {}...'.format(prefix, ', '.join(SUPPORTED_CONF_FILES)),
+            'Feel free to move the setting elsewhere in one of {}...'.format(
+                prefix,
+                ', '.join(SUPPORTED_CONF_FILES),
+            ),
         )
 
-        with io.open('.isort.cfg', mode, encoding='UTF-8') as f:
+        with io.open(DEFAULT_CONF_FILE, mode, encoding='UTF-8') as f:
             f.write(contents)
 
 

--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -69,12 +69,13 @@ def main(argv=None):
             break
     else:
         print(
-            'Could not find a `known_third_party` setting in any of {}.  '
-            'Set up an initial config and run again!'.format(
-                ', '.join(SUPPORTED_CONF_FILES),
-            ),
+            'Creating an .isort.cfg with a known_third_party imports setting. '
+            'Feel free to move the setting to a different config file in one '
+            'of {}...'.format(', '.format(SUPPORTED_CONF_FILES)),
         )
-        return 1
+
+        with io.open('.isort.cfg', 'a', encoding='UTF-8') as f:
+            f.write('[settings]\nknown_third_party = {}\n'.format(third_party))
 
 
 if __name__ == '__main__':

--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -68,14 +68,25 @@ def main(argv=None):
                 f.write(contents)
             break
     else:
+        if os.path.exists('.isort.cfg'):
+            prefix = 'Updating'
+            mode = 'a'
+            contents = 'known_third_party = {}\n'.format(third_party)
+        else:
+            prefix = 'Creating'
+            mode = 'w'
+            contents = '[settings]\nknown_third_party = {}\n'.format(
+                third_party,
+            )
+
         print(
-            'Creating an .isort.cfg with a known_third_party imports setting. '
-            'Feel free to move the setting to a different config file in one '
-            'of {}...'.format(', '.format(SUPPORTED_CONF_FILES)),
+            '{} an .isort.cfg with a known_third_party setting. '
+            'Feel free to move the setting to a different config file in '
+            'one of {}...'.format(prefix, ', '.join(SUPPORTED_CONF_FILES)),
         )
 
-        with io.open('.isort.cfg', 'a', encoding='UTF-8') as f:
-            f.write('[settings]\nknown_third_party = {}\n'.format(third_party))
+        with io.open('.isort.cfg', mode, encoding='UTF-8') as f:
+            f.write(contents)
 
 
 if __name__ == '__main__':

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -115,6 +115,17 @@ def test_integration_extra_file(tmpdir):
             (('.isort.cfg', '[settings]\nknown_third_party = cfgv\n'),),
         ),
         (
+            (('.isort.cfg', '[settings]\ncombine_as_imports = true\n'),),
+            (
+                (
+                    '.isort.cfg',
+                    '[settings]\n'
+                    'combine_as_imports = true\n'
+                    'known_third_party = cfgv\n',
+                ),
+            ),
+        ),
+        (
             (('setup.cfg', '[bdist_wheel]\nuniversal = True\n'),),
             (('.isort.cfg', '[settings]\nknown_third_party = cfgv\n'),),
         ),


### PR DESCRIPTION
This attempts to automate what is currently a manual step. This will create an `.isort.cfg` file with a `known_third_party` section if a `known_third_party` line can't be found. There is also messaging to tell the user that they can move this configuration if they want.