### PR TITLE
Support --settings-path option

### DIFF
--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -57,6 +57,13 @@ def main(argv=None):
             'application directories.  Defaults to `%(default)s`'
         ),
     )
+    parser.add_argument(
+        '--settings-path', default='.',
+        help=(
+            'Directory containing isort config file. '
+            'Defaults to `%(default)s`'
+        ),
+    )
     args = parser.parse_args(argv)
 
     cmd = ('git', 'ls-files', '--', '*.py')
@@ -71,6 +78,7 @@ def main(argv=None):
     third_party = ','.join(sorted(third_party_imports(filenames, appdirs)))
 
     for filename in SUPPORTED_CONF_FILES:
+        filename = os.path.join(args.settings_path, filename)
         if not os.path.exists(filename):
             continue
 
@@ -84,7 +92,8 @@ def main(argv=None):
                 f.write(contents)
             break
     else:
-        if os.path.exists('.isort.cfg'):
+        filename = os.path.join(args.settings_path, '.isort.cfg')
+        if os.path.exists(filename):
             prefix = 'Updating'
             mode = 'a'
             contents = 'known_third_party = {}\n'.format(third_party)
@@ -101,7 +110,13 @@ def main(argv=None):
             'one of {}...'.format(prefix, ', '.join(SUPPORTED_CONF_FILES)),
         )
 
-        with io.open('.isort.cfg', mode, encoding='UTF-8') as f:
+        try:
+            os.makedirs(args.settings_path)
+        except OSError:
+            if not os.path.isdir(args.settings_path):
+                raise
+
+        with io.open(filename, mode, encoding='UTF-8') as f:
             f.write(contents)
 
 

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -163,6 +163,19 @@ def test_integration_src_layout(tmpdir):
         assert tmpdir.join('.isort.cfg').read() == expected
 
 
+def test_integration_settings_path(tmpdir):
+    with tmpdir.as_cwd():
+        src = tmpdir.join('src').ensure_dir()
+        src.join('f.py').write('import cfgv')
+        _make_git()
+
+        assert not main(('--settings-path', 'src'))
+
+        expected = '[settings]\nknown_third_party = cfgv\n'
+        assert src.join('.isort.cfg').read() == expected
+        assert not tmpdir.join('.isort.cfg').check()
+
+
 def test_integration_git_literal_pathspecs_1(tmpdir):
     """an emacs plugin, magit calls pre-commit in this way, see #5"""
     with mock.patch.dict(os.environ, {'GIT_LITERAL_PATHSPECS': '1'}):


### PR DESCRIPTION
Add an option to match isort's `--settings-path`. This allows the user
to specify a different directory for the isort configuration file.