### PR TITLE
Add support for pyproject.toml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ isort configuration file.  It will modify that if it exists, otherwise it'll
 create a brand new `.isort.cfg` file.
 
 The easiest way to get started is to just add a blank `known_third_party =`
-section to your isort configuration.
+section to your isort configuration (or `known_third_party = []` if you are
+using `pyproject.toml`).
 
 ## usage with pre-commit
 


### PR DESCRIPTION
This adds support for the `pyproject.toml` configuration file as discussed in #17.

As we mentioned there, this is intentionally not using a real TOML parser, so it doesn't support all possible states of the input file. In certain situations, it will break the TOML syntax. A similar problem exists with the INI syntax used by the other configuration files, though it cannot break the syntax there.