### PR TITLE
Fix greedy regex matching too much

### DIFF
--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -19,7 +19,7 @@ SUPPORTED_CONF_FILES = (
 )
 THIRD_PARTY_RE = re.compile(r'^known_third_party(\s*)=(\s*?)(?:\S.*)?$', re.M)
 KNOWN_OTHER_RE = re.compile(
-    r'^known_((?!third_party)\w+)\s*=\s*(.*)$', re.M,
+    r'^known_((?!third_party)\w+)\s*=\s*?(.*)$', re.M,
 )
 
 

--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -17,9 +17,11 @@ ENV_BLACKLIST = frozenset(('GIT_LITERAL_PATHSPECS', 'GIT_GLOB_PATHSPECS'))
 SUPPORTED_CONF_FILES = (
     '.editorconfig', '.isort.cfg', 'setup.cfg', 'tox.ini', 'pyproject.toml',
 )
-THIRD_PARTY_RE = re.compile(r'^known_third_party(\s*)=(\s*?)(?:\S.*)?$', re.M)
+THIRD_PARTY_RE = re.compile(
+    r'^known_third_party([ \t]*)=([ \t]*)(?:.*)?$', re.M,
+)
 KNOWN_OTHER_RE = re.compile(
-    r'^known_((?!third_party)\w+)\s*=\s*?(.*)$', re.M,
+    r'^known_((?!third_party)\w+)[ \t]*=[ \t]*(.*)$', re.M,
 )
 
 

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -13,6 +13,7 @@ from seed_isort_config import THIRD_PARTY_RE
 def test_third_party_re():
     assert THIRD_PARTY_RE.search('[isort]\nknown_third_party=cfgv\n')
     assert THIRD_PARTY_RE.search('[isort]\nknown_third_party = cfgv\n')
+    assert THIRD_PARTY_RE.search('[isort]\nknown_third_party\t=\tcfgv\n')
     assert not THIRD_PARTY_RE.search('[isort]\nknown_stdlib = os\n')
     # make sure whitespace isn't greedily matched
     matched = THIRD_PARTY_RE.search('known_third_party=\n').group()
@@ -28,6 +29,7 @@ known_third_party =dummy_thirdparty1,dummy_thirdparty2
     assert KNOWN_OTHER_RE.search(isort_config)
     assert KNOWN_OTHER_RE.search(isort_config.replace(" =", "="))
     assert KNOWN_OTHER_RE.search(isort_config.replace(" =", " = "))
+    assert KNOWN_OTHER_RE.search(isort_config.replace(" =", "\t=\t"))
     # make sure whitespace isn't greedily matched
     negative_match = KNOWN_OTHER_RE.search(isort_config)
     dummy_firstparty_module = "dummy_firstparty1"

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -4,6 +4,7 @@ import subprocess
 import mock
 import pytest
 
+from seed_isort_config import KNOWN_OTHER_RE
 from seed_isort_config import main
 from seed_isort_config import third_party_imports
 from seed_isort_config import THIRD_PARTY_RE
@@ -16,6 +17,28 @@ def test_third_party_re():
     # make sure whitespace isn't greedily matched
     matched = THIRD_PARTY_RE.search('known_third_party=\n').group()
     assert matched == 'known_third_party='
+
+
+def test_known_other_re():
+    isort_config = """
+[settings]
+known_first_party =
+known_third_party =dummy_thirdparty1,dummy_thirdparty2
+"""
+    assert KNOWN_OTHER_RE.search(isort_config)
+    assert KNOWN_OTHER_RE.search(isort_config.replace(" =", "="))
+    assert KNOWN_OTHER_RE.search(isort_config.replace(" =", " = "))
+    # make sure whitespace isn't greedily matched
+    negative_match = KNOWN_OTHER_RE.search(isort_config)
+    dummy_firstparty_module = "dummy_firstparty1"
+    positive_match = KNOWN_OTHER_RE.search(
+        isort_config.replace(
+            "known_first_party =",
+            "known_first_party=" + dummy_firstparty_module,
+        ),
+    )
+    assert negative_match.group(2) == ""
+    assert positive_match.group(2) == dummy_firstparty_module
 
 
 def test_list_third_party_imports(tmpdir):


### PR DESCRIPTION
Fixes asottile/seed-isort-config#40.

Build succeeded in my private Azure DevOps pipeline (I can't make that project public, as I have private repos there).

Tests against https://github.com/jmknoble/testcase-seed-isort-config perform as expected.
