### PR TITLE
better error message when git is missing

### DIFF
--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -97,8 +97,8 @@ def main(argv=None):
     env = {k: v for k, v in os.environ.items() if k not in ENV_BLACKLIST}
     try:
         out = subprocess.check_output(cmd, env=env).decode('UTF-8')
-    except FileNotFoundError:
-        raise FileNotFoundError('Cannot find git. Make sure it is in your PATH')
+    except OSError:
+        raise OSError('Cannot find git. Make sure it is in your PATH')
     filenames = out.splitlines() + args.extra
 
     exclude = re.compile(args.exclude)

--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -95,7 +95,10 @@ def main(argv=None):
 
     cmd = ('git', 'ls-files', '--', '*.py')
     env = {k: v for k, v in os.environ.items() if k not in ENV_BLACKLIST}
-    out = subprocess.check_output(cmd, env=env).decode('UTF-8')
+    try:
+        out = subprocess.check_output(cmd, env=env).decode('UTF-8')
+    except FileNotFoundError:
+        raise FileNotFoundError('Cannot find git. Make sure it is in your PATH')
     filenames = out.splitlines() + args.extra
 
     exclude = re.compile(args.exclude)

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -329,8 +329,10 @@ def test_removing_file_after_git_add(tmpdir):
 def test_missing_git_from_path(tmpdir):
     """expect user-friendly error message for a missing git"""
     with pytest.raises(OSError) as excinfo:
-        with mock.patch.object(subprocess, 'check_output',
-                               side_effect=OSError):
+        with mock.patch.object(
+            subprocess, 'check_output',
+            side_effect=OSError
+        ):
             with tmpdir.as_cwd():
                 _make_git()
                 main(())

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -326,9 +326,13 @@ def test_removing_file_after_git_add(tmpdir):
         assert tmpdir.join('.isort.cfg').read() == expected
 
 
-def test_missing_git_from_path():
+def test_missing_git_from_path(tmpdir):
     """expect user-friendly error message for a missing git"""
-    with pytest.raises(OSError,
-                       match='Cannot find git. Make sure it is in your PATH'):
-        with mock.patch('subprocess.check_output', side_effect=OSError):
-            main()
+    with pytest.raises(OSError) as excinfo:
+        with mock.patch.object(subprocess, 'check_output',
+                               side_effect=OSError):
+            with tmpdir.as_cwd():
+                _make_git()
+                main(())
+    msg, = excinfo.value.args
+    assert msg == 'Cannot find git. Make sure it is in your PATH'

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -331,7 +331,7 @@ def test_missing_git_from_path(tmpdir):
     with pytest.raises(OSError) as excinfo:
         with mock.patch.object(
             subprocess, 'check_output',
-            side_effect=OSError
+            side_effect=OSError,
         ):
             with tmpdir.as_cwd():
                 _make_git()

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -326,7 +326,7 @@ def test_removing_file_after_git_add(tmpdir):
         assert tmpdir.join('.isort.cfg').read() == expected
 
 
-    def test_missing_git_from_path():
+def test_missing_git_from_path():
     """expect user-friendly error message for a missing git"""
     with pytest.raises(OSError,
                        match='Cannot find git. Make sure it is in your PATH'):

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -324,3 +324,11 @@ def test_removing_file_after_git_add(tmpdir):
 
         expected = '[settings]\nknown_third_party=pre_commit\n'
         assert tmpdir.join('.isort.cfg').read() == expected
+
+
+    def test_missing_git_from_path():
+    """expect user-friendly error message for a missing git"""
+    with pytest.raises(OSError,
+                       match='Cannot find git. Make sure it is in your PATH'):
+        with mock.patch('subprocess.check_output', side_effect=OSError):
+            main()


### PR DESCRIPTION
1. I tried to use this with no `git` in `PATH` and got an ambiguous "FileNotFoundError". Adding a more direct error message should be helpful
2. I would like to use "raise .. from" to make the logic more clear, but that won't work in Python 2