### PR TITLE
Do no longer use deprecated repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ This works especially well when integrated with [`pre-commit`][pre-commit].
     rev: v1.9.4
     hooks:
     -   id: seed-isort-config
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21  # pick the isort version you'd like to use from https://github.com/pre-commit/mirrors-isort/releases
+-   repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21  # pick the isort version you'd like to use from https://github.com/timothycrosley/isort/releases
     hooks:
     -   id: isort
 ```


### PR DESCRIPTION
As noted in the README.md of pre-commit/mirrors-isort, that repository
is deprecated.

Instead, `isort` should be used directly.

P.S.: I did not update the version number to the latest `4.3.21-2` on purpose, as then `isort` gets applied to all files, not only Python files - see https://github.com/timothycrosley/isort/issues/1154