### PR TITLE
Add line preservation when changing existing config files

### DIFF
--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -122,9 +122,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         else:
             load = ini_load
             dump = ini_dump
-
+        # use universal line endings (based on system)
+        nl = None
         with open(filename, encoding='UTF-8') as f:
             contents = f.read()
+            # Grab current newlines
+            if type(f.newlines) is tuple:
+                nl = f.newlines[0]
+            else:
+                nl = f.newlines
 
         for match in KNOWN_OTHER_RE.finditer(contents):
             third_party -= set(load(match.group(2)))
@@ -136,7 +142,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             if new_contents == contents:
                 return 0
             else:
-                with open(filename, 'w', encoding='UTF-8') as f:
+                with open(filename, 'w', encoding='UTF-8', newline=nl) as f:
                     f.write(new_contents)
                 return 1
     else:

--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -122,15 +122,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         else:
             load = ini_load
             dump = ini_dump
-        # use universal line endings (based on system)
-        nl = None
-        with open(filename, encoding='UTF-8') as f:
+        with open(filename, encoding='UTF-8', newline='') as f:
             contents = f.read()
-            # Grab current newlines
-            if type(f.newlines) is tuple:
-                nl = f.newlines[0]
-            else:
-                nl = f.newlines
 
         for match in KNOWN_OTHER_RE.finditer(contents):
             third_party -= set(load(match.group(2)))
@@ -142,7 +135,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             if new_contents == contents:
                 return 0
             else:
-                with open(filename, 'w', encoding='UTF-8', newline=nl) as f:
+                with open(filename, 'w', encoding='UTF-8', newline='') as f:
                     f.write(new_contents)
                 return 1
     else:

--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -18,7 +18,7 @@ SUPPORTED_CONF_FILES = (
     '.editorconfig', '.isort.cfg', 'setup.cfg', 'tox.ini', 'pyproject.toml',
 )
 THIRD_PARTY_RE = re.compile(
-    r'^known_third_party([ \t]*)=([ \t]*)(?:.*)?$', re.M,
+    r'^known_third_party([ \t]*)=([ \t]*)(?:[^\r]*)?(\r?)$', re.M,
 )
 KNOWN_OTHER_RE = re.compile(
     r'^known_((?!third_party)\w+)[ \t]*=[ \t]*(.*)$', re.M,
@@ -130,7 +130,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
         if THIRD_PARTY_RE.search(contents):
             third_party_s = dump(sorted(third_party))
-            replacement = fr'known_third_party\1=\2{third_party_s}'
+            replacement = fr'known_third_party\1=\2{third_party_s}\3'
             new_contents = THIRD_PARTY_RE.sub(replacement, contents)
             if new_contents == contents:
                 return 0

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -341,3 +341,61 @@ def test_missing_git_from_path(tmpdir):
                 main(())
             msg, = excinfo.value.args
             assert msg == 'Cannot find git. Make sure it is in your PATH'
+
+
+def test_newline_grab(tmpdir):
+    with tmpdir.as_cwd():
+        tmpcfg = tmpdir.join('.isort.cfg')
+        with open(tmpcfg.strpath, 'w', newline='') as cfg:
+            cfg.write('[settings]\r\nknown_third_party=\r\n')
+        tmpdir.join('g.py').write('import cfgv\n')
+        _make_git()
+
+        assert main(()) == 1
+
+        expected = '[settings]\r\nknown_third_party=cfgv\r\n'
+        with open(tmpcfg.strpath, newline='') as cfg:
+            assert cfg.read() == expected
+
+
+def test_newline_preserve(tmpdir):
+    with tmpdir.as_cwd():
+        tmpcfg = tmpdir.join('.isort.cfg')
+        with open(tmpcfg.strpath, 'w', newline='') as cfg:
+            cfg.write('[settings]\r\nknown_third_party=\r\n')
+        tmpdir.join('g.py').write('import cfgv\n')
+        _make_git()
+
+        assert main(()) == 1
+
+        expected = '[settings]\r\nknown_third_party=cfgv\r\n'
+        with open(tmpcfg.strpath, newline='') as cfg:
+            assert cfg.read() == expected
+
+        with open(tmpcfg.strpath, 'w', newline='') as cfg:
+            cfg.write('[settings]\nknown_third_party=\n')
+        tmpdir.join('g.py').write('import cfgv\n')
+        _make_git()
+
+        assert main(()) == 1
+
+        expected = '[settings]\nknown_third_party=cfgv\n'
+        with open(tmpcfg.strpath, newline='') as cfg:
+            assert cfg.read() == expected
+
+
+def test_newline_mixed(tmpdir):
+    with tmpdir.as_cwd():
+        tmpcfg = tmpdir.join('.isort.cfg')
+        with open(tmpcfg.strpath, 'w', newline='') as cfg:
+            cfg.write('[settings]\r\nknown_third_party=\n')
+        tmpdir.join('g.py').write('import cfgv\n')
+        _make_git()
+
+        assert main(()) == 1
+
+        # In case of mixed line endings we are using first one returned
+        # by fileobj.newlines
+        expected = '[settings]\nknown_third_party=cfgv\n'
+        with open(tmpcfg.strpath, newline='') as cfg:
+            assert cfg.read() == expected

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -13,10 +13,11 @@ from seed_isort_config import THIRD_PARTY_RE
 @pytest.mark.parametrize(
     ('s', 'expected_groups'),
     (
-        ('[isort]\nknown_third_party=\n', ('', '')),
-        ('[isort]\nknown_third_party = foo\n', (' ', ' ')),
-        ('[isort]\nknown_third_party\t=\tfoo\n', ('\t', '\t')),
-        ('[isort]\nknown_third_party =\nknown_wat=wat\n', (' ', '')),
+        ('[isort]\nknown_third_party=\n', ('', '', '')),
+        ('[isort]\nknown_third_party = foo\n', (' ', ' ', '')),
+        ('[isort]\nknown_third_party\t=\tfoo\n', ('\t', '\t', '')),
+        ('[isort]\nknown_third_party =\nknown_wat=wat\n', (' ', '', '')),
+        ('[isort]\nknown_third_party =\r\nknown_wat=wat\r\n', (' ', '', '\r')),
     ),
 )
 def test_known_third_party_re(s, expected_groups):
@@ -295,7 +296,7 @@ def test_exclude(tmpdir):
 def test_returns_zero_no_changes(tmpdir):
     with tmpdir.as_cwd():
         cfg = tmpdir.join('.isort.cfg')
-        cfg.write_binary(b'[settings]\nknown_third_party=cfgv\n')
+        cfg.write(b'[settings]\nknown_third_party=cfgv\n')
         tmpdir.join('f.py').write('import cfgv\n')
         _make_git()
 
@@ -307,7 +308,7 @@ def test_returns_zero_no_changes(tmpdir):
 def test_returns_zero_no_changes_pyproject_toml(tmpdir):
     with tmpdir.as_cwd():
         cfg = tmpdir.join('pyproject.toml')
-        cfg.write_binary(b'[settings]\nknown_third_party=["cfgv"]\n')
+        cfg.write(b'[settings]\nknown_third_party=["cfgv"]\n')
         tmpdir.join('f.py').write('import cfgv\n')
         _make_git()
 
@@ -346,11 +347,11 @@ def test_missing_git_from_path(tmpdir):
 def test_newlines_preserved(tmpdir):
     with tmpdir.as_cwd():
         cfg = tmpdir.join('.isort.cfg')
-        cfg.write_binary(b'[settings]\r\nknown_third_party=\n')
+        cfg.write_binary(b'[settings]\nknown_third_party=\r\n')
         tmpdir.join('g.py').write('import cfgv\n')
         _make_git()
 
         assert main(()) == 1
 
-        expected = b'[settings]\r\nknown_third_party=cfgv\n'
+        expected = b'[settings]\nknown_third_party=cfgv\r\n'
         assert cfg.read_binary() == expected

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -343,7 +343,7 @@ def test_missing_git_from_path(tmpdir):
             assert msg == 'Cannot find git. Make sure it is in your PATH'
 
 
-def test_newline_preserve(tmpdir):
+def test_newlines_preserved(tmpdir):
     with tmpdir.as_cwd():
         cfg = tmpdir.join('.isort.cfg')
         cfg.write_binary(b'[settings]\r\nknown_third_party=\n')

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -295,7 +295,7 @@ def test_exclude(tmpdir):
 def test_returns_zero_no_changes(tmpdir):
     with tmpdir.as_cwd():
         cfg = tmpdir.join('.isort.cfg')
-        cfg.write('[settings]\nknown_third_party=cfgv\n')
+        cfg.write_binary(b'[settings]\nknown_third_party=cfgv\n')
         tmpdir.join('f.py').write('import cfgv\n')
         _make_git()
 
@@ -307,7 +307,7 @@ def test_returns_zero_no_changes(tmpdir):
 def test_returns_zero_no_changes_pyproject_toml(tmpdir):
     with tmpdir.as_cwd():
         cfg = tmpdir.join('pyproject.toml')
-        cfg.write('[settings]\nknown_third_party=["cfgv"]\n')
+        cfg.write_binary(b'[settings]\nknown_third_party=["cfgv"]\n')
         tmpdir.join('f.py').write('import cfgv\n')
         _make_git()
 
@@ -343,59 +343,14 @@ def test_missing_git_from_path(tmpdir):
             assert msg == 'Cannot find git. Make sure it is in your PATH'
 
 
-def test_newline_grab(tmpdir):
-    with tmpdir.as_cwd():
-        tmpcfg = tmpdir.join('.isort.cfg')
-        with open(tmpcfg.strpath, 'w', newline='') as cfg:
-            cfg.write('[settings]\r\nknown_third_party=\r\n')
-        tmpdir.join('g.py').write('import cfgv\n')
-        _make_git()
-
-        assert main(()) == 1
-
-        expected = '[settings]\r\nknown_third_party=cfgv\r\n'
-        with open(tmpcfg.strpath, newline='') as cfg:
-            assert cfg.read() == expected
-
-
 def test_newline_preserve(tmpdir):
     with tmpdir.as_cwd():
-        tmpcfg = tmpdir.join('.isort.cfg')
-        with open(tmpcfg.strpath, 'w', newline='') as cfg:
-            cfg.write('[settings]\r\nknown_third_party=\r\n')
+        cfg = tmpdir.join('.isort.cfg')
+        cfg.write_binary(b'[settings]\r\nknown_third_party=\n')
         tmpdir.join('g.py').write('import cfgv\n')
         _make_git()
 
         assert main(()) == 1
 
-        expected = '[settings]\r\nknown_third_party=cfgv\r\n'
-        with open(tmpcfg.strpath, newline='') as cfg:
-            assert cfg.read() == expected
-
-        with open(tmpcfg.strpath, 'w', newline='') as cfg:
-            cfg.write('[settings]\nknown_third_party=\n')
-        tmpdir.join('g.py').write('import cfgv\n')
-        _make_git()
-
-        assert main(()) == 1
-
-        expected = '[settings]\nknown_third_party=cfgv\n'
-        with open(tmpcfg.strpath, newline='') as cfg:
-            assert cfg.read() == expected
-
-
-def test_newline_mixed(tmpdir):
-    with tmpdir.as_cwd():
-        tmpcfg = tmpdir.join('.isort.cfg')
-        with open(tmpcfg.strpath, 'w', newline='') as cfg:
-            cfg.write('[settings]\r\nknown_third_party=\n')
-        tmpdir.join('g.py').write('import cfgv\n')
-        _make_git()
-
-        assert main(()) == 1
-
-        # In case of mixed line endings we are using first one returned
-        # by fileobj.newlines
-        expected = '[settings]\nknown_third_party=cfgv\n'
-        with open(tmpcfg.strpath, newline='') as cfg:
-            assert cfg.read() == expected
+        expected = b'[settings]\r\nknown_third_party=cfgv\n'
+        assert cfg.read_binary() == expected


### PR DESCRIPTION
When using `seed-isort-config` on windows line endings are changed to `\r\n\` even if they are `\n` in the first place. I believe that `seed-isort-config` should preserve line endings of any file that it changes instead of changing them to system ones. 

This PR solves that by preserving original line endings. 