### PR TITLE
Add line preservation when changing existing config files.

### DIFF
--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -18,7 +18,7 @@ SUPPORTED_CONF_FILES = (
     '.editorconfig', '.isort.cfg', 'setup.cfg', 'tox.ini', 'pyproject.toml',
 )
 THIRD_PARTY_RE = re.compile(
-    r'^known_third_party([ \t]*)=([ \t]*)(?:.*)?$', re.M,
+    r'^known_third_party([ \t]*)=([ \t]*)(?:.*?)?(\r?)$', re.M,
 )
 KNOWN_OTHER_RE = re.compile(
     r'^known_((?!third_party)\w+)[ \t]*=[ \t]*(.*)$', re.M,
@@ -123,7 +123,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             load = ini_load
             dump = ini_dump
 
-        with open(filename, encoding='UTF-8') as f:
+        with open(filename, encoding='UTF-8', newline='') as f:
             contents = f.read()
 
         for match in KNOWN_OTHER_RE.finditer(contents):
@@ -131,12 +131,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
         if THIRD_PARTY_RE.search(contents):
             third_party_s = dump(sorted(third_party))
-            replacement = fr'known_third_party\1=\2{third_party_s}'
+            replacement = fr'known_third_party\1=\2{third_party_s}\3'
             new_contents = THIRD_PARTY_RE.sub(replacement, contents)
             if new_contents == contents:
                 return 0
             else:
-                with open(filename, 'w', encoding='UTF-8') as f:
+                with open(filename, 'w', encoding='UTF-8', newline='') as f:
                     f.write(new_contents)
                 return 1
     else:


### PR DESCRIPTION
This PR make it so `seed-isort-config` respect whatever line endings were user had in they file originally instead of using system ones.

Python regexp doesn't treat the `\r` symbol as part of the line ending. So when using windows line endings only `\n` will be treated as end of line. While `\r` would be a part of matched string.

