### PR TITLE
fix(README): fix pre-commit example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This works especially well when integrated with [`pre-commit`][pre-commit].
     rev: v2.1.1
     hooks:
     -   id: seed-isort-config
--   repo: https://github.com/timothycrosley/isort
+-   repo: https://github.com/pre-commit/mirrors-isort
     rev: 4.3.21  # pick the isort version you'd like to use from https://github.com/timothycrosley/isort/releases
     hooks:
     -   id: isort


### PR DESCRIPTION
In the example pre-commit configuration, change `repo: https://github.com/timothycrosley/isort`  to  `repo:https://github.com/pre-commit/mirrors-isort`.

Using `repo: https://github.com/timothycrosley/isort` for the pre-commit hook works, but it will cause non-python files to also be linted:
```sh
pipenv run pre-commit run --all-files isort
Loading .env environment variables…
isort....................................................................Failed
- hook id: isort
- files were modified by this hook

Fixing /home/mohamed/[...]/computer-header-style-1/computer-header-style-1.component.ts
Fixing /home/mohamed/[...]/contacts/contacts.actions.ts
Fixing /home/mohamed/[...]/redis.conf
[...]
```