### PR TITLE
Fix #25/print changes to stdout

### DIFF
--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -144,7 +144,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 with open(filename, 'w', encoding='UTF-8', newline='') as f:
                     f.write(new_contents)
                 if args.verbose:
-                    known = set(filter(None, load(file_third_party.group(4))))
+                    known = set(filter(None, load(file_third_party.group(3))))
                     print(
                         f'The \'known_third_party\' section in '
                         f'\'{os.path.basename(filename)}\' was changed:\n'

--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -133,7 +133,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         for match in KNOWN_OTHER_RE.finditer(contents):
             third_party -= set(load(match.group(2)))
 
-        if THIRD_PARTY_RE.search(contents):
+        file_third_party = THIRD_PARTY_RE.search(contents)
+        if file_third_party:
             third_party_s = dump(sorted(third_party))
             replacement = fr'known_third_party\1=\2{third_party_s}\4'
             new_contents = THIRD_PARTY_RE.sub(replacement, contents)
@@ -142,6 +143,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             else:
                 with open(filename, 'w', encoding='UTF-8', newline='') as f:
                     f.write(new_contents)
+                if args.verbose:
+                    known = set(filter(None, load(file_third_party.group(4))))
+                    print(
+                        f'The \'known_third_party\' section in '
+                        f'\'{os.path.basename(filename)}\' was changed:\n'
+                        f"Added: {(third_party - known) or None}\n"
+                        f"Removed: {(known - third_party) or None}",
+                    )
                 return 1
     else:
         filename = os.path.join(args.settings_path, '.isort.cfg')

--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -18,7 +18,7 @@ SUPPORTED_CONF_FILES = (
     '.editorconfig', '.isort.cfg', 'setup.cfg', 'tox.ini', 'pyproject.toml',
 )
 THIRD_PARTY_RE = re.compile(
-    r'^known_third_party([ \t]*)=([ \t]*)(?:.*?)?(\r?)$', re.M,
+    r'^known_third_party([ \t]*)=([ \t]*)(.*?)?(\r?)$', re.M,
 )
 KNOWN_OTHER_RE = re.compile(
     r'^known_((?!third_party)\w+)[ \t]*=[ \t]*(.*)$', re.M,
@@ -135,7 +135,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
         if THIRD_PARTY_RE.search(contents):
             third_party_s = dump(sorted(third_party))
-            replacement = fr'known_third_party\1=\2{third_party_s}\3'
+            replacement = fr'known_third_party\1=\2{third_party_s}\4'
             new_contents = THIRD_PARTY_RE.sub(replacement, contents)
             if new_contents == contents:
                 return 0

--- a/seed_isort_config.py
+++ b/seed_isort_config.py
@@ -95,6 +95,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             'Defaults to `%(default)s`'
         ),
     )
+    parser.add_argument(
+        "--verbose", action="store_true",
+        help="Print changes to stdout.",
+    )
     args = parser.parse_args(argv)
 
     cmd = ('git', 'ls-files', '--', '*.py')

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -370,3 +370,21 @@ def test_newlines_preserved(tmpdir):
 
         expected = b'[settings]\nknown_third_party=cfgv\r\n'
         assert cfg.read_binary() == expected
+
+
+def test_verbose_output(tmpdir, capsys):
+    with tmpdir.as_cwd():
+        cfg = tmpdir.join('.isort.cfg')
+        cfg.write_binary(b'[settings]\nknown_third_party=test\r\n')
+        tmpdir.join('g.py').write('import cfgv\n')
+        _make_git()
+
+        assert main(("--verbose",)) == 1
+
+        assert (
+            "The 'known_third_party' section in '.isort.cfg' was "
+            "changed:\nAdded: {'cfgv'}\nRemoved: {'test'}"
+        ) in capsys.readouterr().out
+
+        expected = b'[settings]\nknown_third_party=cfgv\r\n'
+        assert cfg.read_binary() == expected

--- a/tests/seed_isort_config_test.py
+++ b/tests/seed_isort_config_test.py
@@ -13,16 +13,25 @@ from seed_isort_config import THIRD_PARTY_RE
 @pytest.mark.parametrize(
     ('s', 'expected_groups'),
     (
-        ('[isort]\nknown_third_party=\n', ('', '', '')),
-        ('[isort]\nknown_third_party = foo\n', (' ', ' ', '')),
-        ('[isort]\nknown_third_party\t=\tfoo\n', ('\t', '\t', '')),
-        ('[isort]\nknown_third_party =\nknown_wat=wat\n', (' ', '', '')),
-        ('[isort]\r\nknown_third_party=\r\n', ('', '', '\r')),
-        ('[isort]\r\nknown_third_party = foo\r\n', (' ', ' ', '\r')),
-        ('[isort]\r\nknown_third_party\t=\tfoo\r\n', ('\t', '\t', '\r')),
+        ('[isort]\nknown_third_party=\n', ('', '', '', '')),
+        ('[isort]\nknown_third_party = foo\n', (' ', ' ', 'foo', '')),
+        ('[isort]\nknown_third_party\t=\tfoo\n', ('\t', '\t', 'foo', '')),
+        (
+            '[isort]\nknown_third_party =\nknown_wat=wat\n',
+            (' ', '', '', ''),
+        ),
+        ('[isort]\r\nknown_third_party=\r\n', ('', '', '', '\r')),
+        (
+            '[isort]\r\nknown_third_party = foo\r\n',
+            (' ', ' ', 'foo', '\r'),
+        ),
+        (
+            '[isort]\r\nknown_third_party\t=\tfoo\r\n',
+            ('\t', '\t', 'foo', '\r'),
+        ),
         (
             '[isort]\r\nknown_third_party =\r\nknown_wat=wat\r\n',
-            (' ', '', '\r'),
+            (' ', '', '', '\r'),
         ),
     ),
 )


### PR DESCRIPTION
### Problem:
see #25 

### Solution:
Added '--verbose' flag. When set output is printed, when an existing config file is changed.
Output mentions the filename, added and removed modules.

Updated test cases for changed regex and added test case for verbose output.

fixes #25 